### PR TITLE
Clarify python version judgment

### DIFF
--- a/xmlyfetcher
+++ b/xmlyfetcher
@@ -132,15 +132,8 @@ decode_json() {
 
 statement=`cat << EOF
 import json,sys
-from platform import python_version
-v = python_version().split('.')
-if int(v[0]) == 3:
-  if int(v[1]) <=3:
-    from imp import reload
-  else:
-    from importlib import reload
-reload(sys)
-if int(v[0]) == 2:
+if sys.version_info<(3,0,0):
+  reload(sys)
   sys.setdefaultencoding("utf8")
 try:
     print(json.dumps(json.load(sys.stdin)[sys.argv[1]],ensure_ascii=False))


### PR DESCRIPTION
Python 3 默认编码已经是 UTF-8 了，因此并不需要 `reload`与`sys.setdefaultencoding()`，见[StackOverflow](https://stackoverflow.com/a/28127538)；
且`sys.version_info`更加适合判断python版本。

_Originally posted by @Bubbu0129 in https://github.com/smallmuou/xmlyfetcher/pull/20#discussion_r1096883055_